### PR TITLE
Updated algorithm for finding random character name

### DIFF
--- a/commands/seriesroll.js
+++ b/commands/seriesroll.js
@@ -12,7 +12,7 @@ exports.run = async (message, bot) => {
 
     let series = allSeries[message.args.toLowerCase()];
 
-    let characterName = series.names[Math.floor(Math.random() * series.names.length)];
+    let characterName = series.names[Math.floor(Math.random() * (series.names.length + 1) - 0.01)];
 
     let waifu = waifulist.rollList.allWaifu[characterName.toLowerCase()];
 


### PR DESCRIPTION
In old formula, chance of obtaining the last index of series.names was essentially zero as the floor function would round down unless Math.random gave EXACTLY 1.0000. By multiplying by length + 1 the probability space now has an even probability of choosing the last index. I subtracted 0.01 to ensure that an arrayOutOfBounds exception did not occur.